### PR TITLE
add 'advanced' flag to ssm-secret export to support advanced paramater

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Requires docker and docker-compose installed locally.
 * Use the `import` subcommand to create a kubernetes secret from key/values stored under a parameter store path
 * Use the `export` subcommand to copy from a kubernetes secret to a parameter store path
 * Use the `--overwrite` flag to overwrite an existing kubernetes secret or existing parameter store keys.
+* Use the `--advanced` flag to export a kubernetes secret which size is over 4 KB to an advanced parameter.
 * Use the `--tls` flag with the import subcommand to create a kubernetes tls secret instead of the default opaque type
 * Use the `--namespace` flag to to override the kubernetes namespace in the current context
 
@@ -141,6 +142,7 @@ Flags:
   -e, --encode            gzip, base64 encode values in parameter store
   -h, --help              help for export
   -o, --overwrite         if parameter store key exists, overwite its values with those from k8s secret
+  -a, --advanced          if secret size is over 4 KB, store it in an advanced parameter
   -s, --ssm-path string   ssm parameter store path to write data to
 
 Global Flags:

--- a/pkg/cmd/export.go
+++ b/pkg/cmd/export.go
@@ -36,7 +36,7 @@ func (c *CommandOptions) Export(args []string) error {
 		}
 		secrets = encoded
 	}
-	err = c.ssm.PutSecrets(c.ssmPath, secrets, c.overwrite)
+	err = c.ssm.PutSecrets(c.ssmPath, secrets, c.overwrite, c.advanced)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -37,6 +37,7 @@ type CommandOptions struct {
 	ssm           *ssm.Client
 	k8s           *k8s.K8sClient
 	overwrite     bool
+	advanced	  bool
 	encode        bool
 	toEnvironment bool
 	tls           bool
@@ -67,6 +68,7 @@ func NewCommandOptions() *CommandOptions {
 		ssm:           svc,
 		k8s:           kclient,
 		overwrite:     false,
+		advanced:	   false,
 		encode:        false,
 		toEnvironment: false,
 		tls:           false,
@@ -95,6 +97,7 @@ func init() {
 	exportCmd.Flags().StringVarP(&cli.ssmPath, "ssm-path", "s", cli.ssmPath, "ssm parameter store path to write data to")
 	exportCmd.MarkFlagRequired("ssm-path")
 	exportCmd.Flags().BoolVarP(&cli.overwrite, "overwrite", "o", cli.overwrite, "if parameter store key exists, overwite its values with those from k8s secret")
+	exportCmd.Flags().BoolVarP(&cli.advanced, "advanced", "o", cli.advanced, "if the secret size is over 4 KB but less than 8 KB, export it to an advanced parameter")
 	exportCmd.Flags().BoolVarP(&cli.encode, "encode", "e", cli.encode, "gzip, base64 encode values in parameter store")
 }
 

--- a/pkg/ssm/ssm.go
+++ b/pkg/ssm/ssm.go
@@ -129,7 +129,7 @@ func (c *Client) EncodeSecrets(secrets map[string]string) (map[string]string, er
 	return secrets, nil
 }
 
-func (c *Client) PutSecrets(parampath string, secrets map[string]string, overwrite bool) error {
+func (c *Client) PutSecrets(parampath string, secrets map[string]string, overwrite bool, advanced bool) error {
 
 	for k, v := range secrets {
 
@@ -137,12 +137,19 @@ func (c *Client) PutSecrets(parampath string, secrets map[string]string, overwri
 			fmt.Printf("warn: secret key %s has no value, ignoring\n", k)
 			continue
 		}
+
+		tier := "Standard"
+		if advanced == true {
+			tier = "Advanced"
+		}
+
 		key := parampath + "/" + k
 		pinput := &ssm.PutParameterInput{
 			Name:      aws.String(key),
 			Type:      aws.String("SecureString"),
 			Value:     aws.String(v),
 			Overwrite: aws.Bool(overwrite),
+			Tier:	   aws.String(tier)
 		}
 		resp, err := c.PutParameter(pinput)
 		if err != nil {

--- a/pkg/ssm/ssm_test.go
+++ b/pkg/ssm/ssm_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 	"time"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -139,7 +140,7 @@ func TestSsmPutSecrets(t *testing.T) {
 	}
 
 	t.Run("test PutSecrets returns expected results", func(t *testing.T) {
-		err := mockssm.PutSecrets("/foo", mockSecrets, false)
+		err := mockssm.PutSecrets("/foo", mockSecrets, false, false)
 		assert.Nil(t, err)
 	})
 
@@ -149,7 +150,16 @@ func TestSsmPutSecrets(t *testing.T) {
 		"null":   "",
 	}
 	t.Run("test PutSecrets with no value is ignored", func(t *testing.T) {
-		err := mockssm.PutSecrets("/foo", mockSecrets, false)
+		err := mockssm.PutSecrets("/foo", mockSecrets, false, false)
+		assert.Nil(t, err)
+	})
+
+	mockSecrets = map[string]string{
+		"passwd": "SuperSecretSquirrelPassword",
+		"token":  []string{strings.Repeat("*", 4100)}
+	}
+	t.Run("test PutSecrets with secret size over 4 kb", func(t *testing.T) {
+		err := mockssm.PutSecrets("/foo", mockSecrets, false, true)
 		assert.Nil(t, err)
 	})
 }


### PR DESCRIPTION
add 'advanced' flag to ssm-secret export to support advanced paramater which support more than 4 kb in size